### PR TITLE
Makefile now uses $(MYPROJECT) for both the .java and .class file

### DIFF
--- a/project/Makefile
+++ b/project/Makefile
@@ -5,7 +5,7 @@ HEADERS=$(MODULES:=.h)
 
 MYPROJECT=template
 
-all: $(HEADERS) template.class libsysinfo/libsysinfo.so
+all: $(HEADERS) $(MYPROJECT).class libsysinfo/libsysinfo.so
 
 $(MYPROJECT).class: $(MYPROJECT).java libsysinfo/libsysinfo.so
 	javac $<


### PR DESCRIPTION
Spotted a small (I presume) error where the Makefile had a `MYPROJECT` variable that it was using for the `.java` file, but not the `.class` file.

- Bence